### PR TITLE
Support new version crypto library

### DIFF
--- a/lib/src/signature_method.dart
+++ b/lib/src/signature_method.dart
@@ -1,5 +1,6 @@
 library signature_method;
 
+import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
 typedef String Sign(String key, String text);
@@ -28,13 +29,13 @@ class SignatureMethod {
 abstract class SignatureMethods {
   /// http://tools.ietf.org/html/rfc5849#section-3.4.2
   static final SignatureMethod HMAC_SHA1 = new SignatureMethod("HMAC-SHA1", (key, text) {
-    HMAC hmac = new HMAC(new SHA1(), key.codeUnits);
-    hmac.add(text.codeUnits);
+    HMAC hmac = new Hmac(sha1, key.codeUnits);
+    List<int> bytes = hmac.convert(text.codeUnits).bytes;
 
     // The output of the HMAC signing function is a binary
     // string. This needs to be base64 encoded to produce
     // the signature string.
-    return CryptoUtils.bytesToBase64(hmac.close());
+    return BASE64.encode(bytes);
   });
 
   /// http://tools.ietf.org/html/rfc5849#section-3.4.3


### PR DESCRIPTION
Hello @kumar8600.
I found that `dart-oauth1` does not work with latest crypto library.

- `HMAC` renamed to `Hmac`
- `SHA1` constructor deleted
- `CryptoUtils` deleted

https://github.com/dart-lang/crypto/blob/master/CHANGELOG.md

Thank you.